### PR TITLE
Just a link updated to newer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Terraform enables you to safely and predictably create, change, and improve prod
 - [Hashicorp Terraform Blog](https://www.hashicorp.com/blog/category/terraform)
 - [Introduction to Terraform](https://www.terraform.io/intro/)
 - [Terraform Documentation](https://www.terraform.io/docs/)
-- [Terraform GitHub Actions](https://github.com/hashicorp/terraform-github-actions) :skull:
+- [Terraform GitHub Actions](https://github.com/hashicorp/setup-terraform) :skull:
 - [Terraform learn](https://learn.hashicorp.com/terraform/)
 
 ## Community


### PR DESCRIPTION
Previously Terraform github action repo used to be on link https://github.com/hashicorp/terraform-github-actions
But now this repository is no longer actively developed or maintained so I have updated the new link as https://github.com/hashicorp/setup-terraform

A message from previous repo
This hashicorp/terraform-github-actions repository is no longer actively developed or maintained. It has been superseded by the hashicorp/setup-terraform GitHub action.